### PR TITLE
ci/add-prettier-and-editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.md]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+max_line_length = off

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,5 +1,5 @@
 name: Lint markdown
-on: [pull-request]
+on: pull_request
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,16 @@
+name: Lint markdown
+on: [pull-request]
+permissions:
+  contents: read
+jobs:
+  lint-markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v3
+      - name: Install dependencies
+        run: npm ci
+      - name: Test (prettier)
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+node_modules/

--- a/GPG.md
+++ b/GPG.md
@@ -13,8 +13,8 @@ This only needs to be done once, the configuration below then becomes per machin
 
 To configure a key locally, or otherwise use an existing key on a machine:
 
-* [Telling Git about your signing key][3]
-* [Sign git commits on GitHub with GPG in macOS][4]
+- [Telling Git about your signing key][3]
+- [Sign git commits on GitHub with GPG in macOS][4]
 
 I used these guides to configure a GPG key to be used for autosigning via `git`, in this order:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Notes
 
-I find writing is a good way of summarising my understanding of topics, and when I inevitably do forget something, having a series of bulleted notes is often the quickest way to regain the context about something. Sometimes this can also consist of a series of steps I have written for doing takss that I need infrequently enough that I don't ever properly memorise them.
+I find writing is a good way of summarising my understanding of topics, and when I inevitably do forget something, having a series of bulleted notes is often the quickest way to regain the context about something. Sometimes this can also consist of a series of steps I have written for doing tasks that I need infrequently enough that I don't ever properly memorise them.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Notes
 
-I find writing is a good way of summarising my understanding of topics, and when I inevitably do forget something, having a series of bulleted notes is often the quickest way to regain the context about something. Sometimes this can also consist of a series of steps I have written for doing tasks that I need infrequently enough that I don't ever properly memorise them.
+I find writing is a good way of summarising my understanding of topics, and when I inevitably do forget something, having a series of bulleted notes is often the quickest way to regain the context about something.
+Sometimes this can also consist of a series of steps I have written for doing tasks that I need infrequently enough that I don't ever properly memorise them.
+
+This repository's contents should follow the [semantic line breaks specification][1].
+
+[1]: https://sembr.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "notes",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "notes",
+      "version": "1.0.0",
+      "devDependencies": {
+        "prettier": "3.1.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/lukeify/notes.git"
   },
+  "scripts": {
+    "test": "prettier . --check"
+  },
   "devDependencies": {
     "prettier": "3.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "notes",
+  "version": "1.0.0",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukeify/notes.git"
+  },
+  "devDependencies": {
+    "prettier": "3.1.1"
+  }
+}


### PR DESCRIPTION
Introduces `editorconfig` to control formatting rules for this repository, also introduces `prettier` to enable markdown file formatting and CI checks.