### PR TITLE
fix/nginx

### DIFF
--- a/.wordlist.spellcheck.txt
+++ b/.wordlist.spellcheck.txt
@@ -117,6 +117,7 @@ latencies
 lifecycle
 Lightsail
 lookups
+lukeify
 LUKS
 macOS
 macOS's

--- a/Brotli with Nginx.md
+++ b/Brotli with Nginx.md
@@ -29,7 +29,8 @@ The instructions present in the installation guide on [<span data-nospell>google
 
     ```bash
     cd nginx-1.27.1
-    ./configure --with-compat --add-dynamic-module=/path/to/ngx_brotli
+   # Provide the path to the built `nginx_brotli`
+    ./configure --with-compat --add-dynamic-module=../ngx_brotli
     ```
 
 4. Move the compiled module files:

--- a/Brotli with Nginx.md
+++ b/Brotli with Nginx.md
@@ -23,7 +23,7 @@ The instructions present in the installation guide on [<span data-nospell>google
     cd ../../../..
     ```
 
-    If updating the cloned repository, run `git pull --recruse-submodules` instead.
+    If updating the cloned repository, run `git pull --recurse-submodules` instead.
 
 3. Switch to the `nginx` directory and run the "Dynamically loaded" steps, taking care to ensure the compilation output from `nginx -V` is included when running `./configure`.
 

--- a/Brotli with Nginx.md
+++ b/Brotli with Nginx.md
@@ -56,7 +56,12 @@ If you are dealing with PGP key issues with Nginx's package repositories:
 - [Updating the PGP Key for NGINX Software][3]
 - [Ubuntu installation guide][4]
 
+## Automation
+
+I have automated this process somewhat—see the corresponding script in the repository [lukeify/scripts][5].
+
 [1]: https://github.com/google/ngx_brotli
 [2]: https://github.com/google/ngx_brotli?tab=readme-ov-file#installation
 [3]: https://blog.nginx.org/blog/updating-pgp-key-for-nginx-software
 [4]: https://nginx.org/en/linux_packages.html#Ubuntu
+[5]: https://github.com/lukeify/scripts/blob/main/src/compile_brotli_for_nginx.sh

--- a/Brotli with Nginx.md
+++ b/Brotli with Nginx.md
@@ -8,8 +8,8 @@ The instructions present in the installation guide on [<span data-nospell>google
 1. Clone the latest version of `nginx` that is installed on your system.
 
     ```bash
-    wget https://nginx.org/download/nginx-1.27.0.tar.gz
-    tar -xf nginx-1.27.0.tar.gz
+    wget https://nginx.org/download/nginx-1.27.1.tar.gz
+    tar -xf nginx-1.27.1.tar.gz
     ```
 
 2. Clone `ngx_brotli`, and follow the steps listed in the first "Statically compiled" section of the repository.
@@ -28,7 +28,7 @@ The instructions present in the installation guide on [<span data-nospell>google
 3. Switch to the `nginx` directory and run the "Dynamically loaded" steps, taking care to ensure the compilation output from `nginx -V` is included when running `./configure`.
 
     ```bash
-    cd nginx-1.27.0
+    cd nginx-1.27.1
     ./configure --with-compat --add-dynamic-module=/path/to/ngx_brotli
     ```
 


### PR DESCRIPTION
Some improvements to the NGINX documentation.

1. Update the latest version of `nginx` in the snippet examples (`1.27.0` → `1.27.1`).
2. Provide an actual path to `ngx_brotli` for the `configure` command instead of an exemplar.
3. Fixes a spelling error in a git command (`recruse` → `recurse`).